### PR TITLE
Documentation: Add contract comments + publish documentation to GH pages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Generate Latest Schema Files
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --example schema
+
+      - name: Generate Rust Docs
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-deps
+
+      - name: Stage Cargo Docs
+        run: |
+          # Add redirect page to inner doc index
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=group_member_approval_smart_contract\">" >> ./target/doc/index.html
+          # Create doc deployment location
+          mkdir ./pages-files
+          # Move documentation to its configured location in settings
+          cp -r target/doc ./pages-files/docs
+
+      - name: Deploy Docs to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        with:
+          branch: gh-pages
+          folder: pages-files
+
       - name: Optimize Contract
         run: make optimize
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "group-member-approval-smart-contract"
-version = "1.0.0"
+version = "1.0.2"
 authors = ["Jake Schwartz <jschwartz@figure.com>", "Pierce Trey <ptrey@figure.com>"]
 edition = "2021"
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2023 Figure Technologies
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
-## Group Member Approval Smart Contract
+# Group Member Approval Smart Contract
 This smart contract provides a way for group members to assert, on chain, their intention to become a member of a
 [Provenance Blockchain Group](https://docs.cosmos.network/main/modules/group).
 
 This solves an issue in the groups module: any admin of any group can add a member to a group without their knowledge.  
 In order to create an ecosystem that respects group member involvement, this grants group members the ability to 
 explicitly state that they intended to become a member of a group.
+
+## Status
+[![Latest Release][release-badge]][release-latest]
+[![Apache 2.0 License][license-badge]][license-url]
+
+[license-badge]: https://img.shields.io/github/license/FigureTechnologies/group-member-approval-smart-contract.svg
+[license-url]: https://github.com/FigureTechnologies/group-member-approval-smart-contract/blob/main/LICENSE
+[release-badge]: https://img.shields.io/github/tag/FigureTechnologies/group-member-approval-smart-contract.svg
+[release-latest]: https://github.com/FigureTechnologies/group-member-approval-smart-contract/releases/latest
+
+## Documentation
+
+For more information on the internal composition of the contract, view the [published documentation](https://figuretechnologies.github.io/group-member-approval-smart-contract/).
 
 ## Contract Instantiation
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -7,6 +7,19 @@ use crate::types::core::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use cosmwasm_std::{entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response};
 use provwasm_std::{ProvenanceMsg, ProvenanceQuery};
 
+/// The entry point used when an account instantiates a stored code wasm payload of this contract on
+/// the Provenance Blockchain.
+///
+/// # Parameters
+///
+/// * `deps` A dependencies object provided by the cosmwasm framework.  Allows access to useful
+/// resources like contract internal storage and a querier to retrieve blockchain objects.
+/// * `env` An environment object provided by the cosmwasm framework.  Describes the contract's
+/// details, as well as blockchain information at the time of the transaction.
+/// * `info` A message information object provided by the cosmwasm framework.  Describes the sender
+/// of the instantiation message, as well as the funds provided as an amount during the transaction.
+/// * `msg` A custom instantiation message defined by this contract for creating the initial
+/// configuration used by the contract.
 #[entry_point]
 pub fn instantiate(
     deps: DepsMut<ProvenanceQuery>,
@@ -17,6 +30,20 @@ pub fn instantiate(
     instantiate_contract(deps, env, info, msg)
 }
 
+/// The entry point used when an account initiates an execution process defined in the contract.
+/// This defines the primary purposes of the contract.
+///
+/// # Parameters
+///
+/// * `deps` A dependencies object provided by the cosmwasm framework.  Allows access to useful
+/// resources like contract internal storage and a querier to retrieve blockchain objects.
+/// * `env` An environment object provided by the cosmwasm framework.  Describes the contract's
+/// details, as well as blockchain information at the time of the transaction.
+/// * `info` A message information object provided by the cosmwasm framework.  Describes the sender
+/// of the instantiation message, as well as the funds provided as an amount during the transaction.
+/// * `msg` A custom execution message enum defined by this contract to allow multiple different
+/// processes to be defined for the singular execution route entry point allowed by the
+/// cosmwasm framework.
 #[entry_point]
 pub fn execute(
     deps: DepsMut<ProvenanceQuery>,
@@ -31,6 +58,18 @@ pub fn execute(
     }
 }
 
+/// The entry point used when an account invokes the contract to retrieve information.  Allows
+/// access to the internal storage information in an immutable manner.
+///
+/// # Parameters
+///
+/// * `deps` A dependencies object provided by the cosmwasm framework.  Allows access to useful
+/// resources like contract internal storage and a querier to retrieve blockchain objects.
+/// * `_env` An environment object provided by the cosmwasm framework.  Describes the contract's
+/// details, as well as blockchain information at the time of the transaction.  Unused by this
+/// function, but required by cosmwasm for successfully defined query entrypoint.
+/// * `msg` A custom query message enum defined by this contract to allow multiple different results
+/// to be determined for this route.
 #[entry_point]
 pub fn query(
     deps: Deps<ProvenanceQuery>,
@@ -42,6 +81,18 @@ pub fn query(
     }
 }
 
+/// The entry point used when the contract admin migrates an existing instance of this contract to
+/// a new stored code instance on chain.
+///
+/// # Parameters
+///
+/// * `deps` A dependencies object provided by the cosmwasm framework.  Allows access to useful
+/// resources like contract internal storage and a querier to retrieve blockchain objects.
+/// * `_env` An environment object provided by the cosmwasm framework.  Describes the contract's
+/// details, as well as blockchain information at the time of the transaction.  Unused by this
+/// function, but required by cosmwasm for successfully defined migration entrypoint.
+/// * msg` A custom migrate message enum defined by this contract to allow multiple different
+/// results of invoking the migrate endpoint.
 #[entry_point]
 pub fn migrate(
     deps: DepsMut<ProvenanceQuery>,

--- a/src/execute/approve_group_membership.rs
+++ b/src/execute/approve_group_membership.rs
@@ -8,6 +8,25 @@ use provwasm_std::{
 };
 use result_extensions::ResultExtensions;
 
+/// Invoked via the contract's execution functionality.  Adds an attribute to the signer that
+/// denotes that they affirm their membership in a [Provenance Blockchain Group](https://docs.cosmos.network/main/modules/group)
+/// by setting an int value on the designated attribute equal to the group identifier.  Note:
+/// Cosmwasm does not expose functionality to query the group module, so this route does not do any
+/// verification that the signer is actually a member of the approved group.  However, consenting to
+/// either being or becoming a member of a group is simply an act of compliance.  False claims made
+/// herein can be queried from the standard chain routes, which allows external consumers of this
+/// attribute to verify this statement after it has been made.  The route does, however, validate
+/// that the account does not already have an attribute value affirming the existing group,
+/// preventing duplicate writes.
+///
+/// # Parameters
+///
+/// * `deps` A dependencies object provided by the cosmwasm framework.  Allows access to useful
+/// resources like contract internal storage and a querier to retrieve blockchain objects.
+/// * `info` A message information object provided by the cosmwasm framework.  Describes the sender
+/// of the instantiation message, as well as the funds provided as an amount during the transaction.
+/// * `group_id` The unique identifier of a given group for which the signing account consents to
+/// membership.
 pub fn approve_group_membership(
     deps: DepsMut<ProvenanceQuery>,
     info: MessageInfo,

--- a/src/execute/mod.rs
+++ b/src/execute/mod.rs
@@ -1,1 +1,5 @@
+//! Contains all execution routes used by the [contract file](crate::contract).
+
+/// The core functionality of the contract.  Allows a blockchain account to approve its membership
+/// for a given group id.
 pub mod approve_group_membership;

--- a/src/instantiate/instantiate_contract.rs
+++ b/src/instantiate/instantiate_contract.rs
@@ -6,6 +6,21 @@ use cosmwasm_std::{DepsMut, Env, MessageInfo, Response};
 use provwasm_std::{bind_name, NameBinding, ProvenanceMsg, ProvenanceQuery};
 use result_extensions::ResultExtensions;
 
+/// The main functionality executed when the smart contract is first instantiated.  This creates the
+/// singleton instance of [ContractState] used to verify the attribute name used in the contract,
+/// as well as optionally binding the contract's name if it does not need to be bound after creation
+/// due to namespace restrictions.
+///
+/// # Parameters
+///
+/// * `deps` A dependencies object provided by the cosmwasm framework.  Allows access to useful
+/// resources like contract internal storage and a querier to retrieve blockchain objects.
+/// * `env` An environment object provided by the cosmwasm framework.  Describes the contract's
+/// details, as well as blockchain information at the time of the transaction.
+/// * `info` A message information object provided by the cosmwasm framework.  Describes the sender
+/// of the instantiation message, as well as the funds provided as an amount during the transaction.
+/// * `msg` A custom instantiation message defined by this contract for creating the initial
+/// configuration used by the contract.
 pub fn instantiate_contract(
     deps: DepsMut<ProvenanceQuery>,
     env: Env,

--- a/src/instantiate/mod.rs
+++ b/src/instantiate/mod.rs
@@ -1,1 +1,5 @@
+//! Contains the functionality used in the [contract file](crate::contract) to instantiate an
+//! instance of the contract.
+
+/// The main functionality executed when the smart contract is first instantiated.
 pub mod instantiate_contract;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,29 @@
+//! Group Member Approval Smart Contract
+//!
+//! This contract uses [Cosmwasm](https://github.com/CosmWasm/cosmwasm)'s provided architecture in
+//! conjunction with [Provwasm](#https://github.com/provenance-io/provwasm) to create a wasm smart
+//! contract that can be deployed to and interact with the Provenance Blockchain.
+//!
+//! This solves an issue in the groups module: any admin of any group can add a member to a group
+//! without their knowledge.  In order to create an ecosystem that respects group member involvement,
+//! this grants group members the ability to explicitly state that they intended to become a member
+//! of a group.
+
+/// The entrypoint for all external commands sent to the compiled wasm.
 pub mod contract;
+/// All commands that are available when executing this contract.
 pub mod execute;
+/// Defines the contract instantiation process.
 pub mod instantiate;
+/// Defines the contract migration process.
 pub mod migrate;
+/// Defines the contract query process.
 pub mod query;
+/// Contains all internal storage communication functionality.
 pub mod store;
+/// Contains all declared structs for internal and external communication.
 pub mod types;
+/// Contains helper functionality for contract code facilitation.
 pub mod util;
 
 #[cfg(test)]

--- a/src/migrate/contract_upgrade.rs
+++ b/src/migrate/contract_upgrade.rs
@@ -7,6 +7,15 @@ use provwasm_std::{ProvenanceMsg, ProvenanceQuery};
 use result_extensions::ResultExtensions;
 use semver::Version;
 
+/// The main entrypoint function for running a code migration.  Auxiliary code run when a stored
+/// instance of this contract on chain is migrated over the existing instance.  Verifies that the
+/// new code instance is a newer version than the current version, and then modifies the contract
+/// state to reflect the new version information contained in the stored file.
+///
+/// # Parameters
+///
+/// * `deps` A dependencies object provided by the cosmwasm framework.  Allows access to useful
+/// resources like contract internal storage and a querier to retrieve blockchain objects.
 pub fn contract_upgrade(
     deps: DepsMut<ProvenanceQuery>,
 ) -> Result<Response<ProvenanceMsg>, ContractError> {
@@ -21,6 +30,12 @@ pub fn contract_upgrade(
         .to_ok()
 }
 
+/// Verifies that the executing migration has a valid contract type and contract version based on
+/// the currently-stored values.
+///
+/// # Parameters
+///
+/// * `contract_state` The current contract state instance from the store.
 fn check_valid_migration(contract_state: &ContractState) -> Result<(), ContractError> {
     // Prevent other contracts of different types from migrating over this one
     if CONTRACT_TYPE != contract_state.contract_type {

--- a/src/migrate/mod.rs
+++ b/src/migrate/mod.rs
@@ -1,1 +1,5 @@
+//! Contains the functionality used in the [contract file](crate::contract) to perform a migration
+//! to a new version.
+
+/// The main entrypoint function for running a code migration.
 pub mod contract_upgrade;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,1 +1,4 @@
+//! Contains the functionality used in the [contract file](crate::contract) to perform a contract query.
+
+/// A query that fetches the stored values in the [ContractState](crate::store::contract_state::ContractState).
 pub mod query_contract_state;

--- a/src/query/query_contract_state.rs
+++ b/src/query/query_contract_state.rs
@@ -4,6 +4,12 @@ use cosmwasm_std::{to_binary, Binary, Deps};
 use provwasm_std::ProvenanceQuery;
 use result_extensions::ResultExtensions;
 
+/// Fetches the current values within the [ContractState](crate::store::contract_state::ContractState).
+///
+/// # Parameters
+///
+/// * `deps` A dependencies object provided by the cosmwasm framework.  Allows access to useful
+/// resources like contract internal storage and a querier to retrieve blockchain objects.
 pub fn query_contract_state(deps: Deps<ProvenanceQuery>) -> Result<Binary, ContractError> {
     to_binary(&get_contract_state(deps.storage)?)?.to_ok()
 }

--- a/src/store/contract_state.rs
+++ b/src/store/contract_state.rs
@@ -10,15 +10,34 @@ pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const NAMESPACE_CONTRACT_STATE: &str = "contract_state";
 const CONTRACT_STATE: Item<ContractState> = Item::new(NAMESPACE_CONTRACT_STATE);
 
+/// Stores the core contract configurations created on instantiated and modified on migration.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct ContractState {
+    /// The bech32 address of the account that has admin rights within this contract.
     pub admin: Addr,
+    /// The [Provenance Name Module](https://docs.provenance.io/modules/name-module) fully-qualified
+    /// name that is used to bind attributes to accounts when consenting to group membership.
     pub attribute_name: String,
+    /// A free-form name defining this particular contract instance.  Used for identification on
+    /// query purposes only.
     pub contract_name: String,
+    /// The crate name, used to ensure that newly-migrated instances match the same contract format.
     pub contract_type: String,
+    /// The crate version, used to ensure that newly-migrated instances do not attempt to use an
+    /// identical or older version.
     pub contract_version: String,
 }
 impl ContractState {
+    /// Constructs a new instance of this struct.
+    ///
+    /// # Parameters
+    ///
+    /// * `admin` The bech32 address of the account that has admin rights within this contract.
+    /// * `attribute_name` The [Provenance Name Module](https://docs.provenance.io/modules/name-module)
+    /// fully-qualified name that is used to bind attributes to accounts when consenting to group
+    /// membership.
+    /// * `contract_name` A free-form name defining this particular contract instance.  Used for
+    /// identification on query purposes only.
     pub fn new<S1: Into<String>, S2: Into<String>>(
         admin: Addr,
         attribute_name: S1,
@@ -34,17 +53,33 @@ impl ContractState {
     }
 }
 
+/// Overwrites the existing singleton contract storage instance of [ContractState] with the input
+/// reference.  An error is returned if the store write is unsuccessful.
+///
+/// # Parameters
+///
+/// * `storage` A mutable instance of the contract storage value, allowing internal store
+/// manipulation.
+/// * `contract_state` The new value for which an internal storage write will be done.
 pub fn set_contract_state(
     storage: &mut dyn Storage,
-    contract_info: &ContractState,
+    contract_state: &ContractState,
 ) -> Result<(), ContractError> {
     CONTRACT_STATE
-        .save(storage, contract_info)
+        .save(storage, contract_state)
         .map_err(|e| ContractError::StorageError {
             message: format!("{e:?}"),
         })
 }
 
+/// Fetches the current contract instance of contract state.  This call should never fail because
+/// the state is set on contract instantiation, but an error will be returned if store communication
+/// fails.
+///
+/// # Parameters
+///
+/// * `storage` An immutable instance of the contract storage value, allowing internal store data
+/// fetches.
 pub fn get_contract_state(storage: &dyn Storage) -> Result<ContractState, ContractError> {
     CONTRACT_STATE
         .load(storage)

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,1 +1,4 @@
+//! Contains all type definitions and functionality for interacting with contract internal storage.
+
+/// Contains the functionality for interacting with the singleton contract state value.
 pub mod contract_state;

--- a/src/types/core/error.rs
+++ b/src/types/core/error.rs
@@ -1,26 +1,53 @@
 use cosmwasm_std::StdError;
 use thiserror::Error;
 
+/// The base error enum that is used to wrap any errors that occur throughout contract execution.
 #[derive(Error, Debug)]
 pub enum ContractError {
+    /// Occurs when an error is encountered during a contract execute route invocation.
     #[error("Contract execution on route [{route}] failed: {message}")]
-    ExecuteError { route: String, message: String },
+    ExecuteError {
+        /// The route on which the error occurred.
+        route: String,
+        /// A free-form message describing the nature of the error.
+        message: String,
+    },
 
+    /// Occurs when an error is encountered during contract instantiation.
     #[error("Contract instantiation failed: {message}")]
-    InstantiationError { message: String },
+    InstantiationError {
+        /// A free-form message describing the nature of the error.
+        message: String,
+    },
 
+    /// Occurs when the account invoking a contract route provides an incorrect amount of funds.
     #[error("Invalid funds: {message}")]
-    InvalidFundsError { message: String },
+    InvalidFundsError {
+        /// A free-form message describing the nature of the error.
+        message: String,
+    },
 
+    /// Occurs when an error is encountered during a contract migration.
     #[error("Contract migration failed: {message}")]
-    MigrationError { message: String },
+    MigrationError {
+        /// A free-form message describing the nature of the error.
+        message: String,
+    },
 
+    /// Occurs when the semver library fails an operation.  This wraps the original error to allow
+    /// it to conform with the [ContractError] typing.
     #[error("{0}")]
     SemVerError(#[from] semver::Error),
 
+    /// Occurs when the Cosmwasm Std library fails an operation.  This wraps the original error to
+    /// allow it to conform with the [ContractError] typing.
     #[error("{0}")]
     Std(#[from] StdError),
 
+    /// Occurs when an error is encountered during contract store communication.
     #[error("Contract storage error occurred: {message}")]
-    StorageError { message: String },
+    StorageError {
+        /// A free-form message describing the nature of the error.
+        message: String,
+    },
 }

--- a/src/types/core/mod.rs
+++ b/src/types/core/mod.rs
@@ -1,2 +1,6 @@
+//! Contains all the driving types for base functionality.
+
+/// Defines each custom error that can occur throughout contract execution.
 pub mod error;
+/// Defines each input msg utilized by contract invocations.
 pub mod msg;

--- a/src/types/core/msg.rs
+++ b/src/types/core/msg.rs
@@ -2,28 +2,55 @@ use cosmwasm_std::Uint64;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+/// The msg that is sent to the chain in order to instantiate a new instance of this contract's
+/// stored code.  Used in the functionality defined in [instantiate_contract](crate::instantiate::instantiate_contract::instantiate_contract).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct InstantiateMsg {
+    /// A free-form name defining this particular contract instance.  Used for identification on
+    /// query purposes only.
     pub contract_name: String,
+    /// The [Provenance Name Module](https://docs.provenance.io/modules/name-module) fully-qualified
+    /// name that is used to bind attributes to accounts when consenting to group membership.
     pub attribute_name: String,
+    /// If true, a new [Provenance Name Module](https://docs.provenance.io/modules/name-module) name
+    /// will be bound directly to the contract.  This contract will not function unless a name has
+    /// been bound, but this option exists to remedy a common issue with the name module: If the
+    /// parent name desired is restricted, its owner must manually bind that name to the contract
+    /// after its instantiation.  Attempting a bind of a restricted name will cause instantiation
+    /// to fail.
     pub bind_attribute_name: bool,
 }
 
+/// All defined payloads to be used when executing routes on this contract instance.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    ApproveGroupMembership { group_id: Uint64 },
+    /// A route that allows the signing account to approve its membership to a
+    /// [Provenance Blockchain Group](https://docs.cosmos.network/main/modules/group) by adding an
+    /// attribute to their account that includes the given group id.  This invokes the functionality
+    /// defined in [approve_group_membership](crate::execute::approve_group_membership::approve_group_membership).
+    ApproveGroupMembership {
+        /// The unique identifier of the group for which the signing account consents to membership.
+        group_id: Uint64,
+    },
 }
 
+/// All defined payloads to be used when querying routes on this contract instance.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
+    /// A route that returns the current [ContractState](crate::store::contract_state::ContractState)
+    /// value stored in state.  Invokes the functionality defined in [query_contract_state](crate::query::query_contract_state::query_contract_state).
     QueryContractState {},
 }
 
+/// All defined payloads to be used when migrating to a new instance of this contract.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MigrateMsg {
+    /// The standard migration route that modifies [ContractState](crate::store::contract_state::ContractState)
+    /// to include the new values defined in a target code instance.  Invokes the functionality
+    /// defined in [contract_upgrade](crate::migrate::contract_upgrade::contract_upgrade).
     ContractUpgrade {},
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,1 +1,4 @@
+//! Contains all types and base functionality used to construct the logic of the contract.
+
+/// Contains all the driving types for base functionality.
 pub mod core;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,2 +1,4 @@
+//!
+
 pub mod prov_helpers;
 pub mod route_helpers;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,6 @@
-//!
+//! Additional functionality that does not strictly belong to a category.  Global helpers.
 
+/// Utility functions that assist in Provenance Blockchain communication and data parsing.
 pub mod prov_helpers;
+/// Utility functions that assist in performing common tasks needed by routes.
 pub mod route_helpers;

--- a/src/util/prov_helpers.rs
+++ b/src/util/prov_helpers.rs
@@ -1,6 +1,14 @@
 use cosmwasm_std::{from_binary, Uint64};
 use provwasm_std::{AttributeValueType, Attributes};
 
+/// Parses all group ids from the [Provenance Blockchain Attributes](https://docs.provenance.io/modules/account)
+/// provided by filtering for all values that match the given name and have an assigned int value.
+///
+/// # Parameters
+///
+/// * `attributes` Attributes fetched via a chain query.
+/// * `name` A [Provenance Blockchain Name Module](https://docs.provenance.io/modules/name-module)
+/// name used to write the attribute.
 pub fn get_group_id_attribute_values<S: Into<String>>(
     attributes: &Attributes,
     name: S,

--- a/src/util/route_helpers.rs
+++ b/src/util/route_helpers.rs
@@ -2,6 +2,14 @@ use crate::types::core::error::ContractError;
 use cosmwasm_std::MessageInfo;
 use result_extensions::ResultExtensions;
 
+/// Verifies that the provided info does not include and funds, ensuring that the account invoking
+/// the contract does not accidentally store funds in the contract that cannot be retrieved due to
+/// lack of tracking.
+///
+/// # Parameters
+///
+/// * `info` A message information object provided by the cosmwasm framework.  Describes the sender
+/// of the instantiation message, as well as the funds provided as an amount during the transaction.
 pub fn check_funds_are_empty(info: &MessageInfo) -> Result<(), ContractError> {
     if !info.funds.is_empty() {
         ContractError::InvalidFundsError {


### PR DESCRIPTION
# Description
This PR adds documentation to the entirety of the contract's functions and mods, and starts publishing docs to GH pages.  Additionally, it properly establishes the license and adds cool tags/documentation links to the readme.

This also bumps the contract version to `v1.0.2` because this will include a new release that adds the doc comments to the kotlin client dependency, as well as bumping a few patch versions of contract deps.