### PR TITLE
Bugfix: sc-258302 - Fix publication by adding correct key id

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,6 +99,6 @@ jobs:
           echo "Publishing release for version [$RELEASE_VERSION]"
           ./kotlin-tools/gradlew publishToSonatype $(if [ "${{github.event.release.prerelease}}" = "true" ]; then echo 'closeSonatypeStagingRepository'; else echo 'closeAndReleaseSonatypeStagingRepository'; fi) \
             -Pversion=$RELEASE_VERSION \
-            -Psigning.keyId=69C08EA0 -Psigning.password="${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}" -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg \
+            -Psigning.keyId="${{ secrets.OSSRH_GPG_SECRET_KEY_ID }}" -Psigning.password="${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}" -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg \
             --info \
             --project-dir ./kotlin-tools


### PR DESCRIPTION
# Description
There's a rotating key id, so this env var inclusion needs to occur before maven publishes will work again.