### PR TITLE
Revert "swap signing key id to match other similar repos"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,8 +93,8 @@ jobs:
 
       - name: Publish to Maven Central
         env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_ACCESS_TOKEN_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_ACCESS_TOKEN_PASSWORD }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         run: |
           echo "Publishing release for version [$RELEASE_VERSION]"
           ./kotlin-tools/gradlew publishToSonatype $(if [ "${{github.event.release.prerelease}}" = "true" ]; then echo 'closeSonatypeStagingRepository'; else echo 'closeAndReleaseSonatypeStagingRepository'; fi) \


### PR DESCRIPTION
There were new github secrets created with a new username/password for publishing to public sonatype - `OSSRH_ACCESS_TOKEN_USERNAME` and `OSSRH_ACCESS_TOKEN_PASSWORD`. 

Instead of making new ones and leaving the old ones broken, I have now updated the old secrets to have the new values. This will allow all of the other repos doing some public publishing to keep using the same credentials without a change. 

This PR reverts to the old keys (with the new values) so that we can avoid having duplicates